### PR TITLE
make the entity store sortable withtout changing the original data

### DIFF
--- a/src/app/modules/entity/entity-table/entity-table.component.html
+++ b/src/app/modules/entity/entity-table/entity-table.component.html
@@ -1,0 +1,49 @@
+<div class="table-box">
+  <div class="table-container">
+    <table
+      #table
+      mat-table
+      matSort
+      [ngClass]="getTableClass()"
+      [dataSource]="dataSource"
+      (matSortChange)="sort($event.active, $event.direction)">
+
+      <ng-container [matColumnDef]="column.name" *ngFor="let column of model.columns">
+        <ng-container *ngIf="column.sortable">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header>
+            {{column.title}}
+          </th>
+        </ng-container>
+
+        <ng-container *ngIf="!column.sortable">
+          <th mat-header-cell *matHeaderCellDef>
+            {{column.title}}
+          </th>
+        </ng-container>
+
+        <ng-container *ngIf="!column.html; else cellHTML">
+          <td mat-cell *matCellDef="let entity" class="mat-cell-text"
+            [ngClass]="getCellClass(entity, column)">
+            {{valueAccessor(entity, column)}}
+          </td>
+        </ng-container>
+
+        <ng-template #cellHTML>
+          <td mat-cell *matCellDef="let entity" class="mat-cell-text"
+            [ngClass]="getCellClass(entity, column)"
+            [innerHTML]="getValue(entity, column)">
+          </td>
+        </ng-template>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="headers;"></tr>
+      <tr mat-row
+        *matRowDef="let entity; columns: headers;"
+        [ngClass]="getRowClass(entity)"
+        (click)="selectEntity(entity)">
+      </tr>
+
+    </table>
+  </div>
+
+</div>

--- a/src/app/modules/entity/entity-table/entity-table.component.ts
+++ b/src/app/modules/entity/entity-table/entity-table.component.ts
@@ -1,0 +1,128 @@
+import {
+  Component,
+  Input,
+  Output,
+  EventEmitter,
+  ChangeDetectorRef,
+  ChangeDetectionStrategy,
+  OnInit,
+  OnDestroy
+} from '@angular/core';
+
+import { Observable } from 'rxjs';
+import t from 'typy';
+
+import {
+  Entity,
+  EntityTableModel,
+  EntityTableColumn
+} from '../shared/entity.interface';
+import { EntityStore } from '../shared/store';
+import { EntityStoreController } from '../shared/controller';
+
+@Component({
+  selector: 'fadq-entity-table',
+  templateUrl: './entity-table.component.html',
+  styleUrls: ['./entity-table.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class EntityTableComponent implements OnInit, OnDestroy {
+
+  private controller: EntityStoreController;
+
+  @Input()
+  get store(): EntityStore<Entity> {
+    return this._store;
+  }
+  set store(value: EntityStore<Entity>) {
+    this._store = value;
+  }
+  private _store: EntityStore<Entity>;
+
+  @Input()
+  get model(): EntityTableModel {
+    return this._model;
+  }
+  set model(value: EntityTableModel) {
+    this._model = value;
+  }
+  private _model: EntityTableModel;
+
+  @Output() select = new EventEmitter<Entity>();
+
+  get headers(): string[] {
+    return this.model.columns
+      .filter((column: EntityTableColumn) => column.visible !== false)
+      .map((column: EntityTableColumn) => column.name);
+  }
+
+  get dataSource(): Observable<Entity[]> {
+    return this.store.observable;
+  }
+
+  constructor(private cdRef: ChangeDetectorRef) {
+    this.controller = new EntityStoreController()
+      .withChangeDetector(this.cdRef);
+  }
+
+  ngOnInit() {
+    this.controller.bind(this.store);
+    // TODO: Clear sort when records change
+  }
+
+  ngOnDestroy() {
+    this.controller.unbind();
+  }
+
+  valueAccessor(entity: Entity, column: EntityTableColumn) {
+    return t(entity.data, column.name).safeObject;
+  }
+
+  sort(property: string, direction: string) {
+    if (direction === 'asc' || direction === 'desc') {
+      this.store.sorter.set({property, direction});
+    } else {
+      this.store.sorter.reset();
+    }
+  }
+
+  selectEntity(entity: Entity) {
+    if (!this.model.selection) {
+      return;
+    }
+
+    this.controller.updateEntityState(entity, {
+      focused: true,
+      selected: true
+    }, true);
+    this.select.emit(entity);
+  }
+
+  getTableClass(): { [key: string]: boolean; } {
+    const selection = this.model.selection || false;
+    return {
+      'fadq-entity-table-with-selection': selection
+    };
+  }
+
+  getRowClass(entity: Entity): { [key: string]: boolean; } {
+    const func = this.model.rowClassFunc;
+    if (func instanceof Function) {
+      return func(entity);
+    }
+
+    const state = this.store.getEntityState(entity);
+    return {
+      'fadq-entity-table-row-selected': state.selected
+    };
+  }
+
+  getCellClass(entity: Entity, column: EntityTableColumn): { [key: string]: boolean; } {
+    const func = this.model.cellClassFunc;
+    if (func instanceof Function) {
+      return func(entity, column);
+    }
+    return {};
+  }
+
+}

--- a/src/app/modules/entity/shared/entity.interface.ts
+++ b/src/app/modules/entity/shared/entity.interface.ts
@@ -22,3 +22,28 @@ export interface Entity<T = { [key: string]: any }, M = EntityMeta> {
 export interface State {
   [key: string]: boolean;
 }
+
+export interface EntityTableModel {
+  columns: EntityTableColumn[];
+  selection: boolean;
+  rowClassFunc?: (entity: Entity) => {
+    [key: string]: boolean;
+  };
+  cellClassFunc?: (entity: Entity, column: EntityTableColumn) => {
+    [key: string]: boolean;
+  };
+}
+
+export interface EntityTableColumn {
+  name: string;
+  title: string;
+  visible?: boolean;
+  html?: boolean;
+  sortable?: boolean;
+  filterable?: boolean;
+}
+
+export interface EntitySortClause {
+  property: string;
+  direction: string;
+}

--- a/src/app/modules/entity/shared/entity.utils.ts
+++ b/src/app/modules/entity/shared/entity.utils.ts
@@ -1,5 +1,7 @@
 import t from 'typy';
 
+import { ObjectUtils } from '@igo2/utils';
+
 import { Entity } from './entity.interface';
 
 export function entitiesAreTheSame(entity1: Entity, entity2: Entity | undefined): boolean {
@@ -59,4 +61,16 @@ export function getEntityIcon(entity: Entity): string {
   }
 
   return icon;
+}
+
+export function sortEntities(
+  entities: Entity[],
+  property: string,
+  direction: string
+): Entity[] {
+  return entities.sort((entity1: Entity, entity2: Entity) => {
+    const property1 = t(entity1.data, property).safeObject;
+    const property2 = t(entity2.data, property).safeObject;
+    return ObjectUtils.naturalCompare(property1, property2, direction);
+  });
 }

--- a/src/app/modules/entity/shared/index.ts
+++ b/src/app/modules/entity/shared/index.ts
@@ -2,5 +2,6 @@ export * from './entity.interface';
 export * from './entity.utils';
 export * from './store';
 export * from './state';
+export * from './sorter';
 export * from './controller';
 export * from './provider';

--- a/src/app/modules/entity/shared/sorter.ts
+++ b/src/app/modules/entity/shared/sorter.ts
@@ -1,0 +1,40 @@
+import { BehaviorSubject } from 'rxjs';
+
+import { Entity, EntitySortClause } from './entity.interface';
+import { sortEntities } from './entity.utils';
+
+export class EntitySorter<T extends Entity> {
+
+  public clause$ = new BehaviorSubject<EntitySortClause | undefined>(undefined);
+
+  get observable(): BehaviorSubject<EntitySortClause | undefined> {
+    return this.clause$;
+  }
+
+  get clause(): EntitySortClause | undefined {
+    return this.clause$.value;
+  }
+
+  constructor() {}
+
+  set(clause: EntitySortClause) {
+    this.clause$.next(clause);
+  }
+
+  reset() {
+    this.clause$.next(undefined);
+  }
+
+  sort(entities: T[]): T[] {
+    entities = entities.slice();
+    if (this.clause === undefined) {
+      return entities;
+    }
+
+    return sortEntities(
+      entities,
+      this.clause.property,
+      this.clause.direction
+    ) as T[];
+  }
+}

--- a/src/app/modules/entity/shared/store.ts
+++ b/src/app/modules/entity/shared/store.ts
@@ -1,25 +1,30 @@
-import { BehaviorSubject, Observable, Subscription, combineLatest } from 'rxjs';
-import { debounceTime, map } from 'rxjs/operators';
+import { BehaviorSubject, Observable, Subject, Subscription, combineLatest, merge } from 'rxjs';
+import { debounceTime, map, distinctUntilChanged, first, skip, share } from 'rxjs/operators';
 
-import { Entity, State } from './entity.interface';
+import { Entity, State, EntitySortClause } from './entity.interface';
 import { EntityState } from './state';
+import { EntitySorter } from './sorter';
+import { sortEntities } from './entity.utils';
 
 export class EntityStore<T extends Entity, S extends { [key: string]: boolean } = State> {
 
   private entities$ = new BehaviorSubject<T[]>([]);
-  private state$$: Subscription;
+  private watcher$$: Subscription;
 
   get state(): EntityState<S> {
     return this._state;
   }
-  set state(value: EntityState<S>) {
-    this._state = value;
-  }
-  _state: EntityState<S>;
+  private _state: EntityState<S>;
 
-  get observable(): BehaviorSubject<T[]> {
-    return this.entities$;
+  get sorter(): EntitySorter<T> {
+    return this._sorter;
   }
+  private _sorter: EntitySorter<T>;
+
+  get observable(): Subject<T[]> {
+    return this._observable$;
+  }
+  private _observable$ = new Subject<T[]>();
 
   get entities(): T[] {
     return this.entities$.value;
@@ -33,11 +38,9 @@ export class EntityStore<T extends Entity, S extends { [key: string]: boolean } 
     if (state === undefined) {
       state = new EntityState<S>();
     }
-    this.state = state;
-  }
-
-  destroy() {
-    this.state$$.unsubscribe();
+    this._state = state;
+    this._sorter = new EntitySorter();
+    this.watchChanges();
   }
 
   clear(soft = false) {
@@ -48,6 +51,7 @@ export class EntityStore<T extends Entity, S extends { [key: string]: boolean } 
     this.entities$.next(entities);
     if (soft === false) {
       this.state.reset();
+      this.sorter.reset();
     }
   }
 
@@ -72,15 +76,29 @@ export class EntityStore<T extends Entity, S extends { [key: string]: boolean } 
   }
 
   observeBy(filterBy: (entity: T, state: S) => boolean): Observable<T[]> {
-    return combineLatest(this.observable, this.state.observable)
+    return this.observable
       .pipe(
-        debounceTime(50),
-        map((value: [T[], S]) => {
-          const entities = value[0];
+        map((entities: T[]) => {
           return entities.filter((entity: T) => {
             return filterBy(entity, this.getEntityState(entity));
           });
         })
       );
+  }
+
+  private watchChanges() {
+    const combined$ = combineLatest(
+      this.entities$,
+      this.state.observable,
+      this.sorter.observable
+    );
+
+    this.watcher$$ = combined$
+      .pipe(
+        skip(1),
+        debounceTime(50)
+      ).subscribe((value: [T[], Map<string, S>, EntitySortClause]) => {
+        this.observable.next(this.sorter.sort(value[0]));
+      });
   }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
Sorting an entity store would sort the original data


**What is the new behavior?**
An entity store will emit sorted values but won't sort the original data


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
