### PR TITLE
Change the use of layerId for layerAlias

### DIFF
--- a/src/app/modules/address/address-editor-tool/address-editor-tool.component.html
+++ b/src/app/modules/address/address-editor-tool/address-editor-tool.component.html
@@ -1,9 +1,9 @@
 <fadq-address-editor
   [store]="store"
   [map]="map"
-  [layerIdBuildings]="layerIdBuildings"
-  [layerIdBuildingsCorrected]="layerIdBuildingsCorrected"
-  [layerIdCadastre]="layerIdCadastre"
-  [layerIdMun]="layerIdMun"
+  [layerAliasBuildings]="layerAliasBuildings"
+  [layerAliasBuildingsCorrected]="layerAliasBuildingsCorrected"
+  [layerAliasCadastre]="layerAliasCadastre"
+  [layerAliasMun]="layerAliasMun"
   [layerOptions]="layerOptions">
 </fadq-address-editor>

--- a/src/app/modules/address/address-editor-tool/address-editor-tool.component.ts
+++ b/src/app/modules/address/address-editor-tool/address-editor-tool.component.ts
@@ -24,10 +24,10 @@ import { AddressState } from '../address.state';
 })
 export class AddressEditorToolComponent {
 
-  @Input() layerIdBuildings: string;
-  @Input() layerIdBuildingsCorrected: string;
-  @Input() layerIdCadastre: string;
-  @Input() layerIdMun: string;
+  @Input() layerAliasBuildings: string;
+  @Input() layerAliasBuildingsCorrected: string;
+  @Input() layerAliasCadastre: string;
+  @Input() layerAliasMun: string;
   @Input() layerOptions: ImageLayerOptions[];
   /**
    * Store Address

--- a/src/app/modules/cadastre/cadastre-search-tool/cadastre-search-tool.component.ts
+++ b/src/app/modules/cadastre/cadastre-search-tool/cadastre-search-tool.component.ts
@@ -42,7 +42,7 @@ import { CadastreState } from '../cadastre.state';
 })
 export class CadastreSearchToolComponent implements OnInit {
 
-  @Input() layerId: string;
+  @Input() layerAlias: string;
   @Input() layerOptions: ImageLayerOptions;
 
   private imageLayer = undefined;
@@ -408,9 +408,9 @@ export class CadastreSearchToolComponent implements OnInit {
   }
 
   private showCadastreImageLayer(visibility: boolean ) {
-    if (this.layerId && this.layerOptions === undefined) {
+    if (this.layerAlias && this.layerOptions === undefined) {
 
-      const layerCadastreImage: Layer = this.mapState.map.getLayerById(this.layerId);
+      const layerCadastreImage: Layer = this.mapState.map.getLayerByAlias(this.layerAlias);
       if (layerCadastreImage !== undefined) { layerCadastreImage.visible = visibility; }
 
     } else if (this.layerOptions !== undefined) {

--- a/src/lib/address/address-editor/address-editor.component.ts
+++ b/src/lib/address/address-editor/address-editor.component.ts
@@ -89,23 +89,23 @@ export class AddressEditorComponent implements OnInit, OnDestroy {
   /**
    * The layer Id of Buildings Layer
    */
-  @Input() layerIdBuildings: string;
+  @Input() layerAliasBuildings: string;
 
   /**
    * The layer Id of Buildings corrected Layer
    */
-  @Input() layerIdBuildingsCorrected: string;
+  @Input() layerAliasBuildingsCorrected: string;
 
   /**
    * The layer Id of Cadastres Layer
    */
-  @Input() layerIdCadastre: string;
+  @Input() layerAliasCadastre: string;
 
 
   /**
    * The layer Id of Municipalities Layer
    */
-  @Input() layerIdMun: string;
+  @Input() layerAliasMun: string;
 
 
   /**
@@ -315,22 +315,22 @@ export class AddressEditorComponent implements OnInit, OnDestroy {
    * Shows all layers related to this tool
    */
   private showLayers() {
-    this.showLayer('buildings', this.layerIdBuildings === 'buildings');
-    this.showLayer('buildingsCorrected', this.layerIdBuildingsCorrected === 'buildingsCorrected');
-    this.showLayer('mun', this.layerIdMun === 'mun');
-    this.showLayer('cadastre_reno', this.layerIdCadastre === 'cadastre_reno');
+    this.showLayer('buildings', this.layerAliasBuildings === 'buildings');
+    this.showLayer('buildingsCorrected', this.layerAliasBuildingsCorrected === 'buildingsCorrected');
+    this.showLayer('mun', this.layerAliasMun === 'mun');
+    this.showLayer('cadastre_reno', this.layerAliasCadastre === 'cadastre_reno');
   }
 /**
  * Shows layer
- * @param layerId Layer id
+ * @param layerAlias Layer alias
  * @param layerExist Indicates if the layer already exists on the map
  */
-private showLayer(layerId: string, layerExist: boolean) {
-  const layer: Layer = this.map.getLayerById(layerId);
+private showLayer(layerAlias: string, layerExist: boolean) {
+  const layer: Layer = this.map.getLayerByAlias(layerAlias);
   if (layerExist || layer !== undefined) {
     if (layer !== undefined) { layer.visible = true; }
   } else if (this.layerOptions !== undefined) {
-    const layerOptions = this.getLayerOptions(layerId);
+    const layerOptions = this.getLayerOptions(layerAlias);
     if (layerOptions !== undefined) {
       this.layerService.createAsyncLayer(Object.assign({}, layerOptions, {
         visible: true,
@@ -342,12 +342,12 @@ private showLayer(layerId: string, layerExist: boolean) {
 
   /**
    * Gets layer options from the layerOptions list received from the context
-   * @param layerId Layer id
+   * @param layerAlias Layer alias
    * @returns The layer options
    */
-  private getLayerOptions(layerId: string): LayerOptions {
+  private getLayerOptions(layerAlias: string): LayerOptions {
     for (const layerOptions of this.layerOptions) {
-      if (layerOptions.id === layerId) { return layerOptions; }
+      if (layerOptions.alias === layerAlias) { return layerOptions; }
     }
     return undefined;
   }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
For the cadastre search tool and the address editor tool, we used the layer Id to obtain a layer.


**What is the new behavior?**
We now used a layer alias to obtain a layer.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ x ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
