### PR TITLE
Few changes to the save logic of the address editor

### DIFF
--- a/src/lib/address/address-editor/address-editor.component.ts
+++ b/src/lib/address/address-editor/address-editor.component.ts
@@ -253,28 +253,29 @@ export class AddressEditorComponent implements OnInit, OnDestroy {
    * Manages an address save
    */
   private manageSave() {
-    if (this.addressIsSelected) {
-      const dialogSaveRef = this.dialog.open(AddressEditorSaveDialogComponent);
-      this.dialogSave$$ = dialogSaveRef.componentInstance.addressSave.subscribe((response: boolean) => {
-        if (response === true) {
-          this.addressService.modifyAddressGeometry(
-            this.selectedAddressFeature.properties.idAdresseLocalisee,
-            this.selectedAddressFeature
-            ).subscribe(() => {
-              this.closeEdition(false);
-              // Refresh the buildingCorrected layer
-              const layer: Layer = this.map.getLayerByAlias('buildingsCorrected');
-              if (layer.dataSource instanceof WMSDataSource ) {
-                (layer.dataSource as WMSDataSource).refresh();
-              }
-            });
-        }
-      });
-      // unsubscribe
-      dialogSaveRef.afterClosed().subscribe(() => {
-        this.dialogSave$$.unsubscribe();
-      });
-    }
+    // Only one address could be saved
+    if (!this.addressIsSelected) { return; }
+
+    const dialogSaveRef = this.dialog.open(AddressEditorSaveDialogComponent);
+    this.dialogSave$$ = dialogSaveRef.componentInstance.addressSave.subscribe((response: boolean) => {
+      if (response === true) {
+        this.addressService.modifyAddressGeometry(
+          this.selectedAddressFeature.properties.idAdresseLocalisee,
+          this.selectedAddressFeature
+          ).subscribe(() => {
+            this.closeEdition(false);
+            // Refresh the buildingCorrected layer
+            const layer: Layer = this.map.getLayerByAlias('buildingsCorrected');
+            if (layer.dataSource instanceof WMSDataSource ) {
+              (layer.dataSource as WMSDataSource).refresh();
+            }
+          });
+      }
+    });
+    // unsubscribe
+    dialogSaveRef.afterClosed().subscribe(() => {
+      this.dialogSave$$.unsubscribe();
+    });
   }
 
   /**

--- a/src/lib/address/address-editor/address-editor.component.ts
+++ b/src/lib/address/address-editor/address-editor.component.ts
@@ -189,7 +189,6 @@ export class AddressEditorComponent implements OnInit, OnDestroy {
     this.closeEdition(true);
   }
 
-
   /**
    * Blurs the save button
    */
@@ -263,8 +262,11 @@ export class AddressEditorComponent implements OnInit, OnDestroy {
             this.selectedAddressFeature
             ).subscribe(() => {
               this.closeEdition(false);
+              // Refresh the buildingCorrected layer
               const layer: Layer = this.map.getLayerByAlias('buildingsCorrected');
-              (layer.dataSource as WMSDataSource).refresh();
+              if (layer.dataSource instanceof WMSDataSource ) {
+                (layer.dataSource as WMSDataSource).refresh();
+              }
             });
         }
       });
@@ -274,7 +276,6 @@ export class AddressEditorComponent implements OnInit, OnDestroy {
       });
     }
   }
-
 
   /**
    * Close the edition mode
@@ -304,20 +305,20 @@ export class AddressEditorComponent implements OnInit, OnDestroy {
       this.store.load([record.entity]);
     }
 
-    if (this.addressIsSelected) {
-      // Deactivate the selection strategy when an address is selected
-      this.store.deactivateStrategyOfType(FeatureStoreSelectionStrategy);
-      if (this.selectedAddress$$ !== undefined) {
-        this.selectedAddress$$.unsubscribe();
-      }
-      this.buildingNumber$.next(record.entity.properties.noAdresse);
-      this.buildingSuffix$.next(record.entity.properties.suffixeNoCivique);
-      this.selectedAddressFeature = record.entity;
-      this.activateModifyControl();
-      // Add the geometry to the modify control
-      const olFeature = this.store.layer.ol.getSource().getFeatureById(record.entity.properties.idAdresseLocalisee);
-      this.modifyControl.setOlGeometry(olFeature.getGeometry());
+    if (!this.addressIsSelected) { return; }
+
+    // Deactivate the selection strategy when an address is selected
+    this.store.deactivateStrategyOfType(FeatureStoreSelectionStrategy);
+    if (this.selectedAddress$$ !== undefined) {
+      this.selectedAddress$$.unsubscribe();
     }
+    this.buildingNumber$.next(record.entity.properties.noAdresse);
+    this.buildingSuffix$.next(record.entity.properties.suffixeNoCivique);
+    this.selectedAddressFeature = record.entity;
+    this.activateModifyControl();
+    // Add the geometry to the modify control
+    const olFeature = this.store.layer.ol.getSource().getFeatureById(record.entity.properties.idAdresseLocalisee);
+    this.modifyControl.setOlGeometry(olFeature.getGeometry());
   }
 
   /**


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
After saving an address, the related layers have to be hidden. The geometry of the modified address has to be hidden too.


**What is the new behavior?**
The layers and the geometry of the modified geometry are now hidden after a save.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ x ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
