### PR TITLE
Remove of cadastre-ori option search

### DIFF
--- a/src/apps/pes/modules/search/shared/search.enums.ts
+++ b/src/apps/pes/modules/search/shared/search.enums.ts
@@ -1,4 +1,3 @@
 import { FEATURE } from '@igo2/geo';
-import { CADASTRE } from 'src/lib/cadastre';
 
-export const SEARCH_TYPES = [FEATURE, CADASTRE];
+export const SEARCH_TYPES = [FEATURE];

--- a/src/apps/pes/views/portal/portal.component.ts
+++ b/src/apps/pes/views/portal/portal.component.ts
@@ -32,8 +32,6 @@ import {
   SearchState
 } from '@igo2/integration';
 
-import { CADASTRE } from 'src/lib/cadastre/shared/cadastre.enums';
-
 import { SEARCH_TYPES } from 'src/apps/pes/modules/search/shared/search.enums';
 import { ClientState } from 'src/apps/pes/modules/client/client.state';
 import { ClientController } from 'src/apps/pes/modules/client/shared/client-controller';
@@ -233,26 +231,12 @@ export class PortalComponent implements OnInit, OnDestroy {
   }
 
   private onBeforeSearch(searchType?: string, searchTerm?: string) {
-    switch (searchType) {
-      case CADASTRE: {
-        this.onBeforeSearchCadastre();
-        break;
-      }
-      default: {
-        this.onBeforeSearchOthers(searchTerm);
-        break;
-      }
-    }
+    this.onBeforeSearchOthers(searchTerm);
   }
 
   private onBeforeSearchOthers(searchTerm: string) {
     if (this.verifyNullTerm(searchTerm)) { return; }
     this.toolState.toolbox.activateTool('searchResults');
-    this.openSidenav();
-  }
-
-  private onBeforeSearchCadastre() {
-    this.toolState.toolbox.activateTool('cadastre');
     this.openSidenav();
   }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
In the PES app, the search option of cadastre-ori is available.


**What is the new behavior?**
In the PES app, the search option cadastre-ori is removed.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
