### PR TITLE
add a length column in the schema elements and add fill to surfaces.

### DIFF
--- a/src/apps/interne/modules/client/shared/client-schema-element-table.service.ts
+++ b/src/apps/interne/modules/client/shared/client-schema-element-table.service.ts
@@ -1,7 +1,9 @@
 import { Injectable} from '@angular/core';
 
+import OlGeoJSON from 'ol/format/GeoJSON';
+
 import { EntityTableTemplate, EntityTableColumnRenderer } from '@igo2/common';
-import { formatMeasure, squareMetersToAcres, squareMetersToHectares } from '@igo2/geo';
+import { formatMeasure, measureOlGeometryLength, squareMetersToAcres, squareMetersToHectares } from '@igo2/geo';
 
 import { formatDate } from 'src/lib/utils/date';
 import { ClientSchemaElement } from 'src/lib/client';
@@ -62,7 +64,7 @@ export class ClientSchemaElementTableService {
         },
         {
           name: 'properties.superficie',
-          title: 'Superficie(m²)',
+          title: 'Superficie (m²)',
           valueAccessor: (schemaElement: ClientSchemaElement) => {
             const area = schemaElement.properties.superficie;
             return area ? formatMeasure(area, {decimal: 1, locale: 'fr'}) : '';
@@ -82,6 +84,19 @@ export class ClientSchemaElementTableService {
           valueAccessor: (schemaElement: ClientSchemaElement) => {
             const area = schemaElement.properties.superficie;
             return area ? formatMeasure(squareMetersToAcres(area), {decimal: 1, locale: 'fr'}) : '';
+          }
+        },
+        {
+          name: 'longueur',
+          title: 'Longueur - Périmètre (m)',
+          valueAccessor: (schemaElement: ClientSchemaElement) => {
+            let length = 0;
+            const olGeometry = new OlGeoJSON().readGeometry(schemaElement.geometry, {
+              dataProjection: schemaElement.projection,
+              featureProjection: schemaElement.projection
+            });
+            length = measureOlGeometryLength(olGeometry,schemaElement.projection);
+            return length ? formatMeasure(length, {decimal: 1, locale: 'fr'}) : '';
           }
         },
         {

--- a/src/lib/client/schema-element/shared/client-schema-element.utils.ts
+++ b/src/lib/client/schema-element/shared/client-schema-element.utils.ts
@@ -107,7 +107,7 @@ export function createSchemaElementLayerStyle(
       updateSchemaPointText(type, style.getText());
     } else {
       const color = type ? type.color : getSchemaElementDefaultColor();
-      style.getFill().setColor(color.concat([0]));
+      style.getFill().setColor(color.concat([0.3]));
       style.getStroke().setColor(color);
     }
     style.getText().setText(getSchemaElementFeatureText(olFeature, resolution));


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
There is no length column in the schema-element table. There's also no fill to schema-elements polygons.


**What is the new behavior?**
The length column give the length of linestrings en perimeter of polygons. The schema-elements polygons are filled with a 30% opacity.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ X ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
