### PR TITLE
add client-parcel-diagram-selector to PES

### DIFF
--- a/src/apps/pes/modules/client/client-tool/client-tool-item.component.html
+++ b/src/apps/pes/modules/client/client-tool/client-tool-item.component.html
@@ -10,6 +10,9 @@
     [message]="message">
   </fadq-message-inline>
 
+  <div class="fadq-client-tool-bottom-section"></div>
+  <fadq-client-parcel-diagram-selector [store]="controller.diagramStore"></fadq-client-parcel-diagram-selector>
+
   <fadq-client-info-addresses
     [client]="controller.client"
     [map]="controller.map"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
The pes and pes_interne apps dosen't have a client-parcel-diagram-selector.


**What is the new behavior?**
Now, the pes and pes_interne apps have a client-parcel-diagram-selector.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ x ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
