### PR TITLE
Limit RPA schema to only one and correct a bug in the schema transfer

### DIFF
--- a/src/apps/interne/modules/client/shared/client-schema-actions.service.ts
+++ b/src/apps/interne/modules/client/shared/client-schema-actions.service.ts
@@ -179,6 +179,6 @@ function schemaIsOfTypeLSE(ctrl: ClientController): Observable<boolean> {
 
 function schemaCanBeDuplicated(ctrl: ClientController): Observable<boolean> {
   return ctrl.schema$.pipe(
-    map((schema: ClientSchema) => schema !== undefined && schema.type !== ClientSchemaType.LSE)
+    map((schema: ClientSchema) => schema !== undefined && schema.type !== ClientSchemaType.LSE && schema.type !== ClientSchemaType.RPA)
   );
 }

--- a/src/lib/client/schema/client-schema-transfer/client-schema-transfer.component.ts
+++ b/src/lib/client/schema/client-schema-transfer/client-schema-transfer.component.ts
@@ -15,7 +15,7 @@ import { EntityStore, Form, WidgetComponent, OnUpdateInputs } from '@igo2/common
 
 import { Client } from '../../shared/client.interfaces';
 
-import { ClientSchema } from '../shared/client-schema.interfaces';
+import { ClientSchema, ClientSchemaMessageTransferResponse } from '../shared/client-schema.interfaces';
 import { ClientSchemaService } from '../shared/client-schema.service';
 import { ClientSchemaFormService } from '../shared/client-schema-form.service';
 
@@ -88,7 +88,7 @@ export class ClientSchemaTransferComponent implements OnInit, OnUpdateInputs, Wi
    */
   onSubmit(data: {[key: string]: any}) {
     this.clientSchemaService.transferSchema(this.schema, data.numeroClient)
-      .subscribe((messages: string[]) => {
+      .subscribe((messages: ClientSchemaMessageTransferResponse[]) => {
         if (messages.length === 0) {
           this.onSubmitSuccess();
         } else {
@@ -117,8 +117,8 @@ export class ClientSchemaTransferComponent implements OnInit, OnUpdateInputs, Wi
   /**
    * On submit error, display an error message
    */
-  private onSubmitError(messages: string[]) {
-    this.setError(messages[0]);
+  private onSubmitError(messages: ClientSchemaMessageTransferResponse[]) {
+    this.setError(messages[0].libelle);
   }
 
   private setError(text: string | undefined) {

--- a/src/lib/client/schema/shared/client-schema-form.service.ts
+++ b/src/lib/client/schema/shared/client-schema-form.service.ts
@@ -19,12 +19,13 @@ import { ApiService } from '../../../core/api/api.service';
 import { DomainService } from '../../../core/domain/domain.service';
 
 import {
-  validateOnlyOneLSE
+  validateOnlyOneType
 } from './client-schema-validators';
 import {
   ClientSchema,
   ClientSchemaApiConfig
 } from './client-schema.interfaces';
+import { ClientSchemaType } from './client-schema.enums';
 
 @Injectable()
 export class ClientSchemaFormService {
@@ -52,7 +53,8 @@ export class ClientSchemaFormService {
             name: 'info',
             options: {
               validator: Validators.compose([
-                (control: FormGroup) => validateOnlyOneLSE(control, store)
+                (control: FormGroup) => validateOnlyOneType(control, store, ClientSchemaType.LSE),
+                (control: FormGroup) => validateOnlyOneType(control, store, ClientSchemaType.RPA)
               ])
             }
           }, fields)
@@ -75,7 +77,8 @@ export class ClientSchemaFormService {
             name: 'info',
             options: {
               validator: Validators.compose([,
-                (control: FormGroup) => validateOnlyOneLSE(control, store)
+                (control: FormGroup) => validateOnlyOneType(control, store, ClientSchemaType.LSE),
+                (control: FormGroup) => validateOnlyOneType(control, store, ClientSchemaType.RPA)
               ])
             }
           }, fields)
@@ -135,7 +138,8 @@ export class ClientSchemaFormService {
                 Validators.required
               ]),
               errors: {
-                onlyOneLSE: 'client.schema.error.onlyOneLSE'
+                onlyOneLSE: 'client.schema.error.onlyOneLSE',
+                onlyOneRPA: 'client.schema.error.onlyOneRPA'
               }
             },
             inputs: {

--- a/src/lib/client/schema/shared/client-schema-validators.ts
+++ b/src/lib/client/schema/shared/client-schema-validators.ts
@@ -4,19 +4,23 @@ import { EntityStore } from '@igo2/common';
 import { ClientSchemaType } from './client-schema.enums';
 import { ClientSchema } from './client-schema.interfaces';
 
-export function validateOnlyOneLSE(control: FormGroup, store: EntityStore<ClientSchema>): ValidationErrors | null {
+export function validateOnlyOneType(control: FormGroup, store: EntityStore<ClientSchema>,uniqueSchemaType: string): ValidationErrors | null {
   const schemaId = control.controls['id'].value;
   const schemaTypeControl = control.controls['type'];
   const schemaType = schemaTypeControl.value;
 
-  if (schemaType !== ClientSchemaType.LSE) { return null; }
+  if (schemaType !== uniqueSchemaType) { return null; }
 
-  const otherLSESchema = store.all().find((schema: ClientSchema) => {
-    return schema.type === ClientSchemaType.LSE && schema.id !== schemaId;
+  const otherSchema = store.all().find((schema: ClientSchema) => {
+    return schema.type === uniqueSchemaType && schema.id !== schemaId;
   });
 
-  if (otherLSESchema !== undefined) {
-    schemaTypeControl.setErrors({onlyOneLSE: ''});
+  if (otherSchema !== undefined) {
+    if (uniqueSchemaType === ClientSchemaType.LSE) {
+      schemaTypeControl.setErrors({onlyOneLSE: ''});
+    } else if (uniqueSchemaType === ClientSchemaType.RPA){
+      schemaTypeControl.setErrors({onlyOneRPA: ''});
+    }
   }
 
   return null;

--- a/src/lib/client/schema/shared/client-schema.enums.ts
+++ b/src/lib/client/schema/shared/client-schema.enums.ts
@@ -7,5 +7,6 @@ export const ClientSchemaType = {
   INV: 'INV',
   LOC: 'LOC',
   LSE: 'LSE',
-  PLP: 'PLP'
+  PLP: 'PLP',
+  RPA: 'RPA'
 };

--- a/src/lib/client/schema/shared/client-schema.interfaces.ts
+++ b/src/lib/client/schema/shared/client-schema.interfaces.ts
@@ -67,7 +67,11 @@ export interface ClientSchemaUpdateResponse {
 
 export interface ClientSchemaTransferResponse {
   data: null;
-  messages: string[];
+  messages: ClientSchemaMessageTransferResponse[];
+}
+
+export interface ClientSchemaMessageTransferResponse {
+  libelle: string;
 }
 
 export interface ClientSchemaDuplicateResponse {

--- a/src/lib/client/schema/shared/client-schema.service.ts
+++ b/src/lib/client/schema/shared/client-schema.service.ts
@@ -16,7 +16,8 @@ import {
   ClientSchemaUpdateData,
   ClientSchemaUpdateResponse,
   ClientSchemaTransferResponse,
-  ClientSchemaDuplicateResponse
+  ClientSchemaDuplicateResponse,
+  ClientSchemaMessageTransferResponse
 } from './client-schema.interfaces';
 
 @Injectable()
@@ -85,7 +86,7 @@ export class ClientSchemaService {
       );
   }
 
-  transferSchema(schema: ClientSchema, numClient: string): Observable<string[]> {
+  transferSchema(schema: ClientSchema, numClient: string): Observable<ClientSchemaMessageTransferResponse[]> {
     const url = this.apiService.buildUrl(this.apiConfig.update);
     const data = Object.assign({}, schema, {numeroClient: numClient});
     return this.http

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -180,7 +180,7 @@
       "none": "None",
       "error.anneeRequired": "You must enter a year for a production plan or a damage notice",
       "error.onlyOneLSE": "Cannot have more than one « Storage structure » type diagram",
-      "error.onlyOneEPA": "Cannot have more than one « Editing agricultural parcels » type diagram",
+      "error.onlyOneRPA": "Cannot have more than one « Practical biodiversity development 5 RPA » type diagram",
       "placeholder": "Schema",
       "create": "Create",
       "create.tooltip": "Create a schema",

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -181,7 +181,7 @@
       "none": "Aucun", 
       "error.anneeRequired": "Vous devez saisir une année pour un plan de production ou un avis de dommage",
       "error.onlyOneLSE": "Impossible d’avoir plus d’un schéma de type « Structure d’entreposage »",
-      "error.onlyOneEPA": "Impossible d’avoir plus d’un schéma de type « Édition de parcelles agricoles »",
+      "error.onlyOneRPA": "Impossible d’avoir plus d’un schéma de type « Aménagement biodiv. pratique 5 RPA »",
       "placeholder": "Schéma",
       "create": "Créer",
       "create.tooltip": "Créer un schéma",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
More than one RPA schema can be created.
The message following a schema transfer is not displayed

**What is the new behavior?**
Only one RPA schema can be created.
The message after the schema transfer is displayed.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ X ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
